### PR TITLE
Fix invalid PATCH handler in messages API

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -16,31 +16,3 @@ export async function GET() {
         );
     }
 }
-
-export async function PATCH(request: Request, { params }: { params: { id: string } }) {
-    try {
-        const { id } = params;
-        const body = await request.json();
-
-        await connectToDatabase();
-        const message = await Contact.findByIdAndUpdate(
-            id,
-            { $set: body },
-            { new: true }
-        );
-
-        if (!message) {
-            return NextResponse.json(
-                { error: 'Message not found' },
-                { status: 404 }
-            );
-        }
-
-        return NextResponse.json(message);
-    } catch (error) {
-        return NextResponse.json(
-            { error: 'Failed to update message' },
-            { status: 500 }
-        );
-    }
-} 


### PR DESCRIPTION
## Summary
- remove unreachable PATCH handler from `/api/messages` root route

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840229bb934832cbbaf70408fc1d534