### PR TITLE
Implement skill save API call and add basic tests

### DIFF
--- a/__tests__/api/skills.test.ts
+++ b/__tests__/api/skills.test.ts
@@ -1,0 +1,10 @@
+import { GET } from '../../app/api/skills/route'
+
+describe('GET /api/skills', () => {
+  it('returns empty array when SKIP_DB_DURING_BUILD is true', async () => {
+    process.env.SKIP_DB_DURING_BUILD = 'true'
+    const res = await GET()
+    const data = await res.json()
+    expect(data).toEqual([])
+  })
+})

--- a/__tests__/components/SkillsManager.test.tsx
+++ b/__tests__/components/SkillsManager.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SkillsManager from '../../components/admin/SkillsManager'
+
+describe('SkillsManager component', () => {
+  it('renders Add Skill button', () => {
+    render(<SkillsManager skills={[]} onSave={jest.fn()} />)
+    expect(screen.getByText(/Add Skill/i)).toBeInTheDocument()
+  })
+})

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -26,15 +26,31 @@ const AdminDashboard: FC = () => {
 
   const handleSaveSkill = async (skill: Skill) => {
     try {
-      // TODO: Implement the API call to save the skill
-      console.log('Saving skill:', skill);
-      // For now, just update the local state
+      const method = skill._id ? 'PUT' : 'POST';
+      const response = await fetch('/api/skills', {
+        method,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(skill)
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save skill');
+      }
+
+      const savedSkill = await response.json();
+
       setSkills((prevSkills: Skill[]) => {
-        const index = prevSkills.findIndex((s: Skill) => s._id === skill._id);
+        const index = prevSkills.findIndex((s: Skill) => s._id === savedSkill._id);
         if (index >= 0) {
-          return [...prevSkills.slice(0, index), skill, ...prevSkills.slice(index + 1)];
+          return [
+            ...prevSkills.slice(0, index),
+            savedSkill,
+            ...prevSkills.slice(index + 1)
+          ];
         }
-        return [...prevSkills, skill];
+        return [...prevSkills, savedSkill];
       });
     } catch (error) {
       console.error('Error saving skill:', error);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:seed": "ts-node --project tsconfig.scripts.json scripts/init-db.ts",
     "create:admin": "ts-node --project tsconfig.scripts.json scripts/create-admin.ts",
     "seed:sections": "ts-node --project tsconfig.scripts.json scripts/seed-sections.ts",
-    "seed-blogs": "ts-node --project tsconfig.scripts.json scripts/seed-blogs.ts"
+    "seed-blogs": "ts-node --project tsconfig.scripts.json scripts/seed-blogs.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.7.4",
@@ -101,6 +102,11 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- hook up skill saving API call in AdminDashboard
- add Jest configuration and setup
- add minimal tests for the skills API route and the SkillsManager component
- update package.json with testing dependencies and script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684022ddd360832c95a19284af99d39e