### PR TITLE
Move startup script to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts ./scripts
+RUN chmod +x /app/scripts/entrypoint.sh
 COPY --from=builder /app/lib ./lib
 COPY --from=builder /app/models ./models
 COPY --from=builder /app/data ./data
@@ -100,4 +101,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
 
 # Use a shell to run the application so we can see logs
-CMD ["sh", "-c", "node server.js"] 
+CMD ["sh", "/app/scripts/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Tests live under `__tests__` and cover API routes and components. A minimal Jest
 ## Docker
 
 Docker and `docker-compose.yml` are provided. The application image uses environment variables defined in `env.production`. Run the stack with `docker-compose up --build`.
+The container starts via `/app/scripts/entrypoint.sh`, which waits for MongoDB and Redis, fixes image permissions and then runs the server.
 
 ## Comments
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,13 +75,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    command: >
-      sh -c "
-        echo 'Waiting for MongoDB and Redis to be ready...' &&
-        sleep 5 &&
-        find /app/public/images -type d -exec chmod 755 {} \; &&
-        find /app/public/images -type f -exec chmod 644 {} \; &&
-        node server.js"
 
 networks:
   portfolio_network:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Simple startup script used in Docker
+
+echo 'Waiting for MongoDB and Redis to be ready...'
+sleep 5
+find /app/public/images -type d -exec chmod 755 {} \;
+find /app/public/images -type f -exec chmod 644 {} \;
+exec node server.js


### PR DESCRIPTION
## Summary
- add `/app/scripts/entrypoint.sh`
- copy the entrypoint in Dockerfile and run it as the default command
- remove inline startup command from docker-compose
- document the entrypoint in the README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6a00c10832cbf607ffd02e87b5a